### PR TITLE
fix warning: BouncyCastle is not compatible with netcoreapp3.1

### DIFF
--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/EasyAbp.Abp.WeChat.Pay.csproj
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/EasyAbp.Abp.WeChat.Pay.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle" Version="1.8.6.1" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
See bcgit/bc-csharp#204.