### PR TITLE
feat(Pay): 微信支付支持公钥验证

### DIFF
--- a/docs/WeChatPay.md
+++ b/docs/WeChatPay.md
@@ -123,6 +123,10 @@ public override void ConfigureServices (ServiceConfigurationContext context)
         op.CertificateBlobName = "WeChatPayCert";
         // 微信支付API证书秘钥，默认为商户名
         op.CertificateSecret = "000000000000000";
+        // 微信支付API证书公钥Id
+        op.PublicKeyId = "PUB_KEY_ID_xxxxx";
+        // 微信支付API证书公钥 要删除头、尾、换行符
+        op.PublicKey = "MIIBIjANBgkqhkiG9w0BAQEFA";
     });
 }
 ```

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/ApiRequests/DefaultWeChatPayApiRequester.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/ApiRequests/DefaultWeChatPayApiRequester.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -70,9 +71,16 @@ namespace EasyAbp.Abp.WeChat.Pay.ApiRequests
             request.Headers.Add("Authorization",
                 await _authorizationGenerator.GenerateAuthorizationAsync(method, url, body, mchId));
 
+            if (options.PublicKeyId.IsNullOrWhiteSpace() == false && options.PublicKeyId.StartsWith("PUB_KEY_ID_"))
+            {
+                request.Headers.Add("Wechatpay-Serial", options.PublicKeyId);
+            }
+
             // Sending the request.
             var client = _httpClientFactory.CreateClient();
-            return await client.SendAsync(request);
+            var response = await client.SendAsync(request);
+
+            return response;
         }
 
         public Task<string> RequestAsync(HttpMethod method, string url, object body, string mchId = null)

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/Options/AbpWeChatPayOptions.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/Options/AbpWeChatPayOptions.cs
@@ -54,6 +54,17 @@ namespace EasyAbp.Abp.WeChat.Pay.Options
         public string CertificateSecret { get; set; }
 
         /// <summary>
+        /// 微信支付公钥Id
+        /// </summary>
+        public string PublicKeyId { get; set; }
+
+        /// <summary>
+        /// 微信支付公钥
+        /// </summary>
+        public string PublicKey { get; set; }
+
+
+        /// <summary>
         /// 构建一个新的 <see cref="AbpWeChatPayModule"/> 实例。
         /// </summary>
         public AbpWeChatPayOptions()

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/Options/DefaultAbpWeChatPayOptionsProvider.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/Options/DefaultAbpWeChatPayOptionsProvider.cs
@@ -41,7 +41,9 @@ public class DefaultAbpWeChatPayOptionsProvider : IAbpWeChatPayOptionsProvider, 
             CertificateBlobContainerName =
                 await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.CertificateBlobContainerName),
             CertificateBlobName = await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.CertificateBlobName),
-            CertificateSecret = await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.CertificateSecret)
+            CertificateSecret = await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.CertificateSecret),
+            PublicKeyId = await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.PublicKeyId),
+            PublicKey = await SettingProvider.GetOrNullAsync(AbpWeChatPaySettings.PublicKey),
         };
     }
 }

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/Security/Extensions/WeChatPaySecurityUtility.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/Security/Extensions/WeChatPaySecurityUtility.cs
@@ -41,5 +41,28 @@ namespace EasyAbp.Abp.WeChat.Pay.Security.Extensions
             gcmBlockCipher.DoFinal(plaintext, length);
             return Encoding.UTF8.GetString(plaintext);
         }
+
+        public static bool Verify(string data, string sign, string publicKey)
+        {
+            if (string.IsNullOrEmpty(data))
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (string.IsNullOrEmpty(sign))
+            {
+                throw new ArgumentNullException(nameof(sign));
+            }
+
+            if (string.IsNullOrEmpty(publicKey))
+            {
+                throw new ArgumentNullException(nameof(publicKey));
+            }
+
+            using var rsa = RSA.Create();
+            rsa.ImportSubjectPublicKeyInfo(Convert.FromBase64String(publicKey), out _);
+            return rsa.VerifyData(Encoding.UTF8.GetBytes(data), Convert.FromBase64String(sign),
+                HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
     }
 }

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/Settings/AbpWeChatPaySettingDefinitionProvider.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/Settings/AbpWeChatPaySettingDefinitionProvider.cs
@@ -66,5 +66,13 @@ public class AbpWeChatPaySettingDefinitionProvider : SettingDefinitionProvider
             AbpWeChatPaySettings.AcceptLanguage,
             _options.AcceptLanguage
         ));
+        context.Add(new SettingDefinition(
+            AbpWeChatPaySettings.PublicKeyId,
+            _options.PublicKeyId
+        ));
+        context.Add(new SettingDefinition(
+            AbpWeChatPaySettings.PublicKey,
+            _options.PublicKey
+        ));
     }
 }

--- a/src/Pay/EasyAbp.Abp.WeChat.Pay/Settings/AbpWeChatPaySettings.cs
+++ b/src/Pay/EasyAbp.Abp.WeChat.Pay/Settings/AbpWeChatPaySettings.cs
@@ -27,4 +27,8 @@ public static class AbpWeChatPaySettings
     public const string CertificateSecret = GroupName + ".CertificateSecret";
 
     public const string AcceptLanguage = GroupName + ".AcceptLanguage";
+
+    public const string PublicKeyId = GroupName + ".PublicKeyId";
+
+    public const string PublicKey = GroupName + ".PublicKey";
 }


### PR DESCRIPTION
- 在 AbpWeChatPayOptions 中添加 PublicKeyId 和 PublicKey 属性
- 在 AbpWeChatPaySettingDefinitionProvider 中添加公钥相关设置
- 修改 DefaultWeChatPayApiRequester，在请求中添加公钥串- 更新 WeChatPayEventRequestHandlingService，支持公钥验证签名- 新增 WeChatPaySecurityUtility.Verify 方法，用于公钥验证- 更新文档，添加公钥配置说明